### PR TITLE
Fix belongs to association to non-primary key field

### DIFF
--- a/lib/fictitious.ex
+++ b/lib/fictitious.ex
@@ -601,8 +601,7 @@ defmodule Fictitious do
         |> detupelize()
         |> Map.get(
           ecto_schema
-          |> get_association_field_ecto_schema(field)
-          |> get_primary_key_field()
+          |> get_related_field_ecto_schema(field)
         )
       )
     end)
@@ -620,8 +619,7 @@ defmodule Fictitious do
         |> detupelize()
         |> Map.get(
           ecto_schema
-          |> get_association_field_ecto_schema(field)
-          |> get_primary_key_field()
+          |> get_related_field_ecto_schema(field)
         )
       )
     end)
@@ -678,8 +676,7 @@ defmodule Fictitious do
         |> detupelize()
         |> Map.get(
           ecto_schema
-          |> get_association_field_ecto_schema(field)
-          |> get_primary_key_field()
+          |> get_related_field_ecto_schema(field)
         )
 
       true ->
@@ -746,8 +743,7 @@ defmodule Fictitious do
         |> detupelize()
         |> Map.get(
           ecto_schema
-          |> get_association_field_ecto_schema(field)
-          |> get_primary_key_field()
+          |> get_related_field_ecto_schema(field)
         )
 
       true ->
@@ -881,7 +877,7 @@ defmodule Fictitious do
     |> get_association_field_key()
   end
 
-  defp get_association_field_key(%Ecto.Association.Has{related_key: key}), do: key
+  defp get_association_field_key(%Ecto.Association.Has{}), do: :not_supported_yet
   defp get_association_field_key(%Ecto.Association.BelongsTo{owner_key: key}), do: key
   defp get_association_field_key(%Ecto.Association.ManyToMany{}), do: :not_supported_yet
 
@@ -899,6 +895,22 @@ defmodule Fictitious do
     :association
     |> ecto_schema.__schema__(field)
     |> Map.get(:related)
+  end
+
+  # Return rekated fields that has a belong to association type.
+  #
+  # Examples:
+  #
+  #   iex> get_related_field_ecto_schema(Person, :nationality)
+  #   :id
+  #
+  #   iex> get_related_field_ecto_schema(SocialMediaInformation, :email)
+  #   :email
+  #
+  defp get_related_field_ecto_schema(ecto_schema, field) do
+    :association
+    |> ecto_schema.__schema__(field)
+    |> Map.get(:related_key)
   end
 
   # Check whether an input struct in an encto belongs to struct.

--- a/lib/fictitious.ex
+++ b/lib/fictitious.ex
@@ -897,7 +897,7 @@ defmodule Fictitious do
     |> Map.get(:related)
   end
 
-  # Return rekated fields that has a belong to association type.
+  # Return related fields that has a belong to association type.
   #
   # Examples:
   #

--- a/lib/schema/person.ex
+++ b/lib/schema/person.ex
@@ -12,6 +12,8 @@ defmodule Fictitious.Person do
     belongs_to :nationality, Country, references: :id, foreign_key: :country_id, type: :id
     belongs_to :parent, Person, references: :id, foreign_key: :parent_id, type: :id
 
+    has_one :social_media_information, SocialMediaInformation, foreign_key: :email
+
     timestamps()
   end
 

--- a/lib/schema/social_media_information.ex
+++ b/lib/schema/social_media_information.ex
@@ -1,0 +1,21 @@
+defmodule Fictitious.SocialMediaInformation do
+  @moduledoc false
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Fictitious.Person
+
+  schema "social_media_informations" do
+    field :is_active, :boolean
+    field :last_login, :date
+
+    belongs_to :user, Person, references: :email, foreign_key: :email, type: :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(person, attrs) do
+    person
+    |> cast(attrs, [:id, :email, :is_active, :last_login])
+  end
+end

--- a/priv/repo/migrations/20200828061808_social_media_information_table.exs
+++ b/priv/repo/migrations/20200828061808_social_media_information_table.exs
@@ -1,0 +1,15 @@
+defmodule Fictitious.Repo.Migrations.CreateSocialMediaInformationTable do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:persons, [:email], name: :email_unique_index)
+
+    create table(:social_media_informations) do
+      add :email, references(:persons, column: :email, type: :string, on_delete: :nothing)
+      add :is_active, :boolean
+      add :last_login, :date
+
+      timestamps()
+    end
+  end
+end

--- a/test/fictitious_test.exs
+++ b/test/fictitious_test.exs
@@ -1,6 +1,6 @@
 defmodule FictitiousTest do
   use ExUnit.Case, async: true
-  alias Fictitious.{Country, Person}
+  alias Fictitious.{Country, Person, SocialMediaInformation}
 
   setup do
     # Explicitly get a connection before each test
@@ -29,6 +29,7 @@ defmodule FictitiousTest do
     {:ok, person} = Fictitious.fictionize(Person)
     person = Fictitious.Repo.preload(person, :nationality)
     assert not is_nil(person.nationality)
+    assert not is_nil(person.email)
   end
 
   test "Fictitious can overwrite the specified belongs to field by passing an id." do
@@ -79,5 +80,12 @@ defmodule FictitiousTest do
   test "Fictitious can give null value to a belongs to association field key." do
     {:ok, person} = Fictitious.fictionize(Person, parent_id: :null)
     assert is_nil(person.parent_id)
+  end
+  
+  test "Fictitious Fictitious does generate the belongs_to associations from non primary key field." do
+    {:ok, social_media_info} = Fictitious.fictionize(SocialMediaInformation)
+    social_media_info = Fictitious.Repo.preload(social_media_info, :user)
+    assert not is_nil(social_media_info.user)
+    assert social_media_info.user.email == social_media_info.email
   end
 end


### PR DESCRIPTION
Previously, the belongs to fictinionize module only support the association to primary key field.
In this Pull Request, I want to update it so that the fictionize can support association to non-primary key field.

I create an example using a `social_media_informations` table and create the belongs to association to `email` field in `persons` table. And also, since the has association is not supported yet, I update the `get_association_field_key` which accept the Ecto Has association.